### PR TITLE
puppetboard-rpm with (few) updated versions, works on RHEL6

### DIFF
--- a/SPECS/python-itsdangerous.spec
+++ b/SPECS/python-itsdangerous.spec
@@ -7,7 +7,7 @@
 %endif
 
 Name:           python-%{upstream_name}
-Version:        0.22
+Version:        0.24
 Release:        1%{?dist}
 Summary:        Python library for passing trusted data to untrusted environments
 License:        BSD
@@ -15,9 +15,9 @@ URL:            http://pythonhosted.org/itsdangerous/
 Source0:        http://pypi.python.org/packages/source/i/%{upstream_name}/%{upstream_name}-%{version}.tar.gz
 # Tarballs on PyPi lack LICENSE, CHANGES, and tests.
 # https://github.com/mitsuhiko/itsdangerous/pull/22
-Source1:        LICENSE
-Source2:        CHANGES
-Source3:        tests.py
+#Source1:        LICENSE
+#Source2:        CHANGES
+#Source3:        tests.py
 BuildArch:      noarch
 BuildRequires:  python2-devel
 BuildRequires:  python-setuptools
@@ -52,7 +52,6 @@ Signatures (JWS).
 %prep
 %setup -q -n %{upstream_name}-%{version}
 rm -r *.egg-info
-cp -p %{SOURCE1} %{SOURCE2} %{SOURCE3} .
 
 %if %{with python3}
 rm -rf %{py3dir}

--- a/SPECS/python-jinja2.spec
+++ b/SPECS/python-jinja2.spec
@@ -17,7 +17,7 @@ License:	BSD
 URL:		http://jinja.pocoo.org/
 Source0:	http://pypi.python.org/packages/source/J/Jinja2/Jinja2-%{version}.tar.gz
 # see https://github.com/mitsuhiko/jinja2/pull/259
-Patch0:		99d0f3165ace0befd9eafd661be6e0c23d5f9ba5.patch
+#Patch0:		99d0f3165ace0befd9eafd661be6e0c23d5f9ba5.patch
 BuildArch:	noarch
 BuildRequires:	python-devel
 BuildRequires:	python-setuptools

--- a/SPECS/python-puppetboard.spec
+++ b/SPECS/python-puppetboard.spec
@@ -2,7 +2,7 @@
 
 Name:           python-%{upstream_name}
 Version:        0.0.4
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Puppetboard is a web interface to PuppetDB aiming to replace the reporting functionality of Puppet Dashboard. 
 License:        Apache v2.0 License
 URL:            https://github.com/nedap/puppetboard
@@ -17,10 +17,13 @@ Requires: python-flask-wtf = 0.8.4
 Requires: python-jinja2 = 2.7
 Requires: python-markupsafe = 0.18
 Requires: python-wtforms = 1.0.4
-Requires: python-werkzeug = 0.9.3
-Requires: python-itsdangerous = 0.22
+Requires: python-werkzeug = 0.9.6
+Requires: python-itsdangerous = 0.24
 Requires: python-pypuppetdb = 0.1.0
-Requires: python-requests >= 1.2.3-PB
+Requires: python-requests >= 2.3.0-PB
+# to get it running with apache
+Requires: httpd
+Requires: mod_wsgi
 
 %description
 Puppetboard is a web interface to PuppetDB aiming to replace the reporting
@@ -38,13 +41,49 @@ rm -r *.egg-info
 
 %install
 %{__python} setup.py install -O1 --skip-build --root %{buildroot}
+# /var/www/puppetboard
+mkdir -p %{buildroot}/var/www/%{upstream_name}/
+cp %{buildroot}/%{python_sitelib}/%{upstream_name}/default_settings.py %{buildroot}/var/www/%{upstream_name}/settings.py
+cat << EOF > %{buildroot}/var/www/puppetboard/wsgi.py
+from __future__ import absolute_import
+import os
+
+# Needed if a settings.py file exists
+os.environ['PUPPETBOARD_SETTINGS'] = '/var/www/puppetboard/settings.py'
+from puppetboard.app import app as application
+EOF
+
+mkdir -p %{buildroot}/etc/httpd/conf.d
+cat << EOFF > %{buildroot}/etc/httpd/conf.d/puppetboard.conf
+DocumentRoot /var/www/puppetboard
+WSGIDaemonProcess puppetboard user=apache group=apache threads=5
+WSGIScriptAlias / /var/www/puppetboard/wsgi.py
+Alias /static /usr/lib/python2.6/site-packages/puppetboard/static
+
+<Directory /usr/lib/python2.6/site-packages/puppetboard>
+    WSGIProcessGroup puppetboard
+    WSGIApplicationGroup %{GLOBAL}
+    Order deny,allow
+    Allow from all
+</Directory>
+EOFF
 
 %files
 %doc LICENSE CHANGELOG.rst README.rst MANIFEST.in
 %{python_sitelib}/%{upstream_name}/
 %{python_sitelib}/%{upstream_name}*.egg-info
+%config /etc/httpd/conf.d/puppetboard.conf
+%config /var/www/puppetboard/wsgi.py
+%ghost /var/www/puppetboard/wsgi.py[co]
+%config /var/www/puppetboard/settings.py
+%ghost /var/www/puppetboard/settings.py[co]
 
 %changelog
+
+* Fri Aug 01 2014 Martin Zehetmayer <angrox@idle.at>  - 0.0.4-3
+- Added configuration files and requirements for apache webserver
+- Added puppetboard directory and configuration files in /var/www/puppetboard
+
 * Tue Feb 19 2014 Johan De Wit <johan@open-future.be> - 0.0.4-2
 - Adjustment of the deplist.  Troubles with some python packages
 

--- a/SPECS/python-requestsPB.spec
+++ b/SPECS/python-requestsPB.spec
@@ -5,7 +5,7 @@
 %endif
 
 Name:           python-requests
-Version:        1.2.3
+Version:        2.3.0
 Release:        PB.0%{?dist}
 Summary:        HTTP library, written in Python, for human beings
 
@@ -14,13 +14,13 @@ URL:            http://pypi.python.org/pypi/requests
 Source0:        http://pypi.python.org/packages/source/r/requests/requests-%{version}.tar.gz
 # Explicitly use the system certificates in ca-certificates.
 # https://bugzilla.redhat.com/show_bug.cgi?id=904614
-Patch0:         python-requests-system-cert-bundle.patch
+#Patch0:         python-requests-system-cert-bundle.patch
 # Unbundle python-charade (a fork of python-chardet).
 # https://bugzilla.redhat.com/show_bug.cgi?id=904623
-Patch1:         python-requests-system-chardet-not-charade.patch
+#Patch1:         python-requests-system-chardet-not-charade.patch
 # Unbundle python-charade (a fork of python-urllib3).
 # https://bugzilla.redhat.com/show_bug.cgi?id=904623
-Patch2:         python-requests-system-urllib3.patch
+#Patch2:         python-requests-system-urllib3.patch
 
 BuildArch:      noarch
 

--- a/SPECS/python-werkzeug.spec
+++ b/SPECS/python-werkzeug.spec
@@ -3,7 +3,7 @@
 %global srcname Werkzeug
 
 Name:           python-werkzeug
-Version:        0.9.3
+Version:        0.9.6
 Release:        2%{?dist}
 Summary:        The Swiss Army knife of Python web development 
 
@@ -16,8 +16,8 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 BuildArch:      noarch
 BuildRequires:  python-devel
 BuildRequires:  python-setuptools-devel
-BuildRequires:  python-sphinx10
-BuildRequires:  python-jinja2-27
+BuildRequires:  python-sphinx
+BuildRequires:  python-jinja2
 
 %description
 Werkzeug


### PR DESCRIPTION
Updated the specs files - build is now working with the current version of RHEL 6.5
